### PR TITLE
fix: specify a valid start page to avoid a warning at build time

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,7 @@
 name: cloud
 title: Bonita Cloud
 version: latest
+start_page: ROOT:index.adoc
 asciidoc:
   attributes:
     page-editable: true


### PR DESCRIPTION
This avoid the following waring at build time:
`[16:22:15.448] WARN (@antora/content-classifier): Start page specified for site not found: bonita::index.adoc`

It doesn't change the behavior since `index.adoc` is used as start page by default when Antora find nothing.