### PR TITLE
ci: fix the surge PR preview workflow

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -1,7 +1,5 @@
 name: Build PR preview
 
-# TODO remove: artificial change to trigger the workflow
-
 on:
   pull_request:
     # To manage 'surge-preview' action teardown, add default event types + closed event type
@@ -22,6 +20,7 @@ jobs:
       BCD_BRANCH: '3.6'
       BONITA_BRANCH: '2022.1'
       TOOLKIT_BRANCH: '1.0'
+      BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
       - name: Build and publish PR preview
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
@@ -35,5 +34,5 @@ jobs:
             --start-page "${{ env.COMPONENT_NAME }}"::index.adoc
             --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}" 
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}" 

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -1,5 +1,7 @@
 name: Build PR preview
 
+# TODO remove: artificial change to trigger the workflow
+
 on:
   pull_request:
     # To manage 'surge-preview' action teardown, add default event types + closed event type


### PR DESCRIPTION
The xref validation failed: test-toolkit now requires bonita@2022.2
