### PR TITLE
refactor: add missing '.adoc' extension in xref

### DIFF
--- a/modules/ROOT/pages/Continuous_Delivery_Build_and_deploy.adoc
+++ b/modules/ROOT/pages/Continuous_Delivery_Build_and_deploy.adoc
@@ -11,7 +11,7 @@ image::images/BuildDeployJob.png[]
 . Click on the image:images/JenkinsPlayButton.png[CDPlayButton] of the "ACTION - Build and Deploy a LivingApp to a non-production runtime" job.
 . Your default build and deploy configuration will be pre-loaded. If needed you can change it (includes the repository URL and branch)
 . Select the target runtime (note that only non-production runtimes are available - to deploy in production see xref:Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud_Prod.adoc[here])
-. If needed, you can fill xref:bcd:ROOT:livingapp_deploy#deployment_descriptor_file[the Deployment Descriptor] in the DEPLOY_JSON field to specify which resources have to be deployed, and with which policy. When used, if a deploy policy is declared in DEPLOY_JSON, it overrides the Development or Production Policies.
+. If needed, you can fill xref:bcd:ROOT:livingapp_deploy.adoc#deployment_descriptor_file[the Deployment Descriptor] in the DEPLOY_JSON field to specify which resources have to be deployed, and with which policy. When used, if a deploy policy is declared in DEPLOY_JSON, it overrides the Development or Production Policies.
 . You can specify the directory that contains the xref:Continuous_Delivery_Test_a_Living_Application.adoc[integration tests] with the INTEGRATION_TESTS_DIR optional field.
 . You can also select the deployment policies to apply. Warning: It may be overridden by policies inside DEPLOY_JSON.
 +

--- a/modules/ROOT/pages/Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud.adoc
+++ b/modules/ROOT/pages/Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud.adoc
@@ -57,7 +57,7 @@ You have several possibilities:
 === (optional) Load a custom Deployment Descriptor file
 
 The BCD deploy command allows to add and extra parameter named `deploy.json` to specify which resources have to be deployed, and with which policy.
-See xref:bcd:ROOT:livingapp_deploy#deployment_descriptor_file[Deploy Living App artifacts | Deployment Descriptor file] for more info.
+See xref:bcd:ROOT:livingapp_deploy.adoc#deployment_descriptor_file[Deploy Living App artifacts | Deployment Descriptor file] for more info.
 
 When used, if a deploy policy is declared in DEPLOY_JSON, it overrides the other Development or Production Policies.
 

--- a/modules/ROOT/pages/Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud.adoc
+++ b/modules/ROOT/pages/Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud.adoc
@@ -25,7 +25,7 @@ You have several possibilities:
  ** Copy from WORKSPACE of the latest completed build
 . Select the target runtime (note that only non-production runtimes are available - to deploy in production see xref:Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud_Prod.adoc[here])
 . You can specify the directory that contains the xref:Continuous_Delivery_Test_a_Living_Application.adoc[integration tests] with the INTEGRATION_TESTS_DIR optional field.
-. You can also select xref:bcd:ROOT:livingapp_deploy#preconfigured_deployment_policies[the deployment policies] to apply.
+. You can also select xref:bcd:ROOT:livingapp_deploy.adoc#preconfigured_deployment_policies[the deployment policies] to apply.
 +
 [NOTE]
 ====

--- a/modules/ROOT/pages/Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud_Prod.adoc
+++ b/modules/ROOT/pages/Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud_Prod.adoc
@@ -53,7 +53,7 @@ The production deployment will be used
 === (optional) Load a custom Deployment Descriptor file
 
 The BCD deploy command allows to add and extra parameter named `deploy.json` to specify which resources have to be deployed, and with which policy.
-See xref:bcd:ROOT:livingapp_deploy#deployment_descriptor_file[Deploy Living App artifacts | Deployment Descriptor file] for more info.
+See xref:bcd:ROOT:livingapp_deploy.adoc#deployment_descriptor_file[Deploy Living App artifacts | Deployment Descriptor file] for more info.
 
 When used, if a deploy policy is declared in DEPLOY_JSON, it overrides the Production Policies.
 

--- a/modules/ROOT/pages/Continuous_Delivery_Test_a_Living_Application.adoc
+++ b/modules/ROOT/pages/Continuous_Delivery_Test_a_Living_Application.adoc
@@ -11,6 +11,6 @@ In order to write and execute integration tests for your Bonita processes the Bo
 
 It requires to include a subfolder in your Bonita project within the same git repository.
 
-Then create your integration tests following the xref:test-toolkit:ROOT:quick-start#quick-start-test[Test Toolkit documentation].
+Then create your integration tests following the xref:test-toolkit:ROOT:quick-start.adoc#quick-start-test[Test Toolkit documentation].
 
 You will be able to launch your integrations tests by specifying into xref:Continuous_Delivery_Deploying_a_Living_Application_to_Bonita_Cloud.adoc[deploy] or xref:Continuous_Delivery_Build_and_deploy.adoc[build and deploy] jobs the folder where you have stored your tests through the INTEGRATION_TESTS_DIR parameter.


### PR DESCRIPTION
Antora xref should always have a file extension; skipping the extension '.adoc' is deprecated from Antora 3.0 onwards.