### PR TITLE
ci: use bonitasoft/actions pr-title-conventional-commits

### DIFF
--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -1,0 +1,15 @@
+name: Commit checks
+
+on:
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -2,23 +2,15 @@ name: Contribution checks
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
-  commit-message-check:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check commit message
-        id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
-        with:
-          pr-body-regex: '(.*\n*)+(.*)'
   pr-content-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - name: Check PR content
-      uses: bonitasoft/actions/packages/pr-diff-checker@v2.1.0
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM"]'
-        extensionsToCheck: '[".adoc"]'
+      - name: Check PR content
+        uses: bonitasoft/actions/packages/pr-diff-checker@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM"]'
+          extensionsToCheck: '[".adoc"]'


### PR DESCRIPTION
This action better conforms to Conventional Commits and provides guidelines to help to fix wrong PR titles.

### Status

It has been successfully tested in https://github.com/bonitasoft/bonita-apps-manager-doc/pull/3
Covers https://github.com/bonitasoft/bonita-documentation-site/issues/422