### PR TITLE
ci: simplify xref validation

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -7,7 +7,7 @@ on:
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
 jobs:
-  build_preview:
+  validate_xref:
     runs-on: ubuntu-22.04
     env:
       COMPONENT_NAME: cloud
@@ -19,15 +19,12 @@ jobs:
       BONITA_BRANCH_2021_1: '2021.1'
       BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
-      - name: Build preview
+      - name: Validate xref
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash --use-multi-repositories
-            --start-page "${{ env.COMPONENT_NAME }}"::index.adoc
-            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
-            --component-with-branches bcd:"${{ env.BCD_BRANCH }},3.6" 
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_2021_1 }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
-            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}" 
+            ./build-preview.bash
+            --component "${{ env.COMPONENT_NAME }}"
+            --branch "${{ env.COMPONENT_BRANCH_NAME }}"


### PR DESCRIPTION
Use the new Antora Atlas feature. There is no more need to reference all dependent components/versions to validate xrefs.