### PR TITLE
fix: rename root pages to follow kebab-case

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,6 +1,7 @@
 = Frequently Asked Questions
-
 :description: This page provides short answers to frequently asked questions about Bonita Cloud.
+:page-aliases: FAQ.adoc
+
 
 == Difference with the On-premise version
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,6 +1,6 @@
 = Getting started with Bonita Cloud
-
 :description: This page shows how to start with Bonita Cloud.
+:page-aliases: Getting_started_with_Bonita_Cloud.adoc
 
 With Bonita Cloud starting a new project has never been easier:
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = Welcome to Bonita Cloud documentation website!
+:description: Explain what Bonita Cloud is and how to use it.
 
 Bonita Cloud offers all the values of the Bonita Enterprise platform and its BCD add-on without the hassle of managing the platform operations (upgrades, infrastructure management...).
 
@@ -7,10 +8,10 @@ Bonita Cloud offers all the values of the Bonita Enterprise platform and its BCD
 
 [.card.card-index]
 --
-xref:Overview.adoc[[.card-title]#Highlights# [.card-body]#pass:q[Discover this new worry-free offer!.]#]
+xref:overview.adoc[[.card-title]#Highlights# [.card-body]#pass:q[Discover this new worry-free offer!.]#]
 --
 
 [.card.card-index]
 --
-xref:Getting_started_with_Bonita_Cloud.adoc[[.card-title]#Getting started# [.card-body]#pass:q[Follow this guide with step-by-step instructions to start using Bonita Cloud.]#]
+xref:getting-started.adoc[[.card-title]#Getting started# [.card-body]#pass:q[Follow this guide with step-by-step instructions to start using Bonita Cloud.]#]
 --

--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,6 @@
 = Bonita Cloud
-
 :description: This page provides an overview of Bonita Cloud.
+:page-aliases: Overview.adoc
 
 ____
 From our business intelligence service to your mission-critical Living Apps, _Bonita Cloud_ makes it easy to deploy, operate, and scale in the cloud.
@@ -12,12 +12,12 @@ Bonita Cloud initial offer includes:
 
 * In our cloud:
  ** You choose your own hosting package (Small, Medium & Large)
- ** You choose which environement you want to deploy (Production or Non production)
+ ** You choose which environment you want to deploy (Production or Non production)
  ** Each subscription comes with additional Cloud components
  *** Bonita Central to Troubleshoot your platform
-  *** Bonita Conitnuous Integration to Build, Test & Deploy your living applications
+  *** Bonita Continuous Integration to Build, Test & Deploy your living applications
 * SLA: Initial & High Availability
-* Support: Gold elite, Gold elite plus or platinium
+* Support: Gold elite, Gold elite plus or platinum
 * Limited cases depending on the package subscribed
 
 == High Level View

--- a/modules/ROOT/taxonomy.adoc
+++ b/modules/ROOT/taxonomy.adoc
@@ -1,5 +1,5 @@
-* xref:Overview.adoc[Bonita Cloud overview]
-* xref:Getting_started_with_Bonita_Cloud.adoc[Getting started]
+* xref:overview.adoc[Bonita Cloud overview]
+* xref:getting-started.adoc[Getting started]
 * Service Level Agreements
  ** xref:Service_Level_Agreement_Service_Availability.adoc[Service Availability]
  ** xref:Service_Level_Agreement_Disaster_recovery.adoc[Disaster recovery]
@@ -27,4 +27,4 @@
   *** xref:Continuous_Delivery_Generic_Actions_Parameters.adoc[Check the parameters of a job]
   *** xref:Continuous_Delivery_Generic_Actions_Replay.adoc[Replay a job]
   *** xref:Continuous_Delivery_Generic_Actions_ChangePWD.adoc[Change your password]
-* xref:FAQ.adoc[Frequently Asked Questions]
+* xref:faq.adoc[Frequently Asked Questions]


### PR DESCRIPTION
This is the convention that must be followed.

Additional changes
  - add missing description in the "index" page
  - fix AsciiDoc attributes declaration (must be right after the page title)
   - fix some typo in the "overview" page


### Notes

Covers https://github.com/bonitasoft/bonita-documentation-site/issues/589

### For reviewers

This is currently not listed in the "Contribution Summary", but redirects for the moved pages have been setup and should be tested:
- https://bonitasoft-bonita-cloud-doc-deploy-pr-64.surge.sh/cloud/latest/FAQ
- https://bonitasoft-bonita-cloud-doc-deploy-pr-64.surge.sh/cloud/latest/Getting_started_with_Bonita_Cloud
- https://bonitasoft-bonita-cloud-doc-deploy-pr-64.surge.sh/cloud/latest/Overview
