### PR TITLE
refactor: remove reference to BCD Vault in the configuration page

### DIFF
--- a/modules/ROOT/taxonomy.adoc
+++ b/modules/ROOT/taxonomy.adoc
@@ -22,6 +22,7 @@
   *** xref:continuous-delivery:living-application/deploying-uib-apps.adoc[Deploy UI Builder applications]
   *** xref:continuous-delivery:living-application/test-a-living-application.adoc[Test a Living Application]
    *** xref:continuous-delivery:living-application/manage-configuration.adoc[Managing Living Application configuration]
+ ** xref:continuous-delivery:encrypting-configuration.adoc[Encrypting configuration parameters]
  ** xref:retrieve-bonita-runtime-logs.adoc[Retrieve Bonita AppRuntime logs]
  ** Basic actions
   *** xref:continuous-delivery:basic-actions/monitoring.adoc[Monitoring a job]

--- a/modules/continuous-delivery/pages/configuring-the-platform.adoc
+++ b/modules/continuous-delivery/pages/configuring-the-platform.adoc
@@ -10,13 +10,11 @@ image:configuration-tab.png[CDConfigTab]
 
 [#repository_credentials]
 == Git repository credentials
-// BCD page is deleted on 4.0, that's why we need to hardcode the 3.6 version
-This job allows you to configure your access to Git but also the xref:3.6@bcd:ROOT:how_to_use_bcd_with_data_encrypted.adoc[BCD vault password].
+This job allows you to configure your access to Git.
 
 . Click on the image:continuous-delivery:jenkins-play-button.png[CDPlayButton] of the "Configure my credentials" job.
 . Enter the Git user that will have access to your repositories
 . Enter the corresponding password for that account.
-. If you are planning to use the BCD Vault, then you can enter the vault password. This field can be left empty.
 . Click on the "Build" button to save the configuration
 . Make sure the job was successful:
 image:credentials-job-result.png[JobResult]
@@ -76,7 +74,7 @@ image:def-deploy-job-result.png[JobResult]
 
 == Default Deploy configuration for UIB applications
 
-This job allows you to define the default build parameters i.e. the repository URL, the branch, and environment to build to avoid having to re-enter the same parameters in the deploy-uib job. 
+This job allows you to define the default build parameters i.e. the repository URL, the branch, and environment to build to avoid having to re-enter the same parameters in the deploy-uib job.
 
 NOTE: This job is only useful for versions of Bonita >= 2024.3/10.2.
 

--- a/modules/continuous-delivery/pages/configuring-the-platform.adoc
+++ b/modules/continuous-delivery/pages/configuring-the-platform.adoc
@@ -10,11 +10,12 @@ image:configuration-tab.png[CDConfigTab]
 
 [#repository_credentials]
 == Git repository credentials
-This job allows you to configure your access to Git.
+This job allows you to configure your access to Git but also the xref:encrypting-configuration.adoc[vault password] used to decrypt your configuration parameters at runtime.
 
 . Click on the image:continuous-delivery:jenkins-play-button.png[CDPlayButton] of the "Configure my credentials" job.
 . Enter the Git user that will have access to your repositories
 . Enter the corresponding password for that account.
+. If you are planning to xref:encrypting-configuration.adoc[encrypt your configuration parameters], then you can enter the vault password. This field can be left empty.
 . Click on the "Build" button to save the configuration
 . Make sure the job was successful:
 image:credentials-job-result.png[JobResult]

--- a/modules/continuous-delivery/pages/encrypting-configuration.adoc
+++ b/modules/continuous-delivery/pages/encrypting-configuration.adoc
@@ -1,0 +1,35 @@
+= Encrypting configuration parameters
+:description: How to encrypt sensitive data stored in Bonita Cloud configuration parameter files.
+
+The configuration parameter files (`parameters-<BCD_CONFIGURATION_NAME>.yml`) stored in the `.bcd_configurations` directory of your Living Application repository (see xref:living-application/manage-configuration.adoc[Managing Living Application configuration]) may contain sensitive data such as passwords or private credentials. Although you may restrict access to your repository, it is strongly recommended to encrypt these files so that the sensitive values are never stored in clear text.
+
+Bonita Cloud supports https://docs.ansible.com/ansible/latest/user_guide/vault.html[Ansible Vault] to encrypt parameter files. Vault-encrypted files are automatically decrypted at runtime, provided that the matching vault password has been configured in the xref:configuring-the-platform.adoc#repository_credentials[Configure my credentials] job.
+
+== Encrypt a parameters file
+
+Use the `ansible-vault encrypt` command to encrypt your parameter file with the vault password configured on your Continuous Delivery platform:
+
+[source,bash]
+----
+ansible-vault encrypt .bcd_configurations/parameters-<BCD_CONFIGURATION_NAME>.yml
+----
+
+When prompted, enter the same password as the one set in the xref:configuring-the-platform.adoc#repository_credentials[Configure my credentials] job. Once encrypted, the file can be safely committed to your Git repository.
+
+== View, edit or decrypt an encrypted file
+
+If you need to inspect or modify the content of an encrypted parameters file, use the corresponding `ansible-vault` commands:
+
+[source,bash]
+----
+ansible-vault view .bcd_configurations/parameters-<BCD_CONFIGURATION_NAME>.yml
+ansible-vault edit .bcd_configurations/parameters-<BCD_CONFIGURATION_NAME>.yml
+ansible-vault decrypt .bcd_configurations/parameters-<BCD_CONFIGURATION_NAME>.yml
+----
+
+Refer to the https://docs.ansible.com/ansible/latest/user_guide/vault.html[Ansible Vault] documentation for detailed information about this feature.
+
+== Caveats
+
+* You may encrypt several files but the password must be the same for all files used together within the same Continuous Delivery platform.
+* The vault password used to encrypt your files must match the one configured in the xref:configuring-the-platform.adoc#repository_credentials[Configure my credentials] job, otherwise the decryption will fail at runtime.

--- a/modules/continuous-delivery/pages/living-application/manage-configuration.adoc
+++ b/modules/continuous-delivery/pages/living-application/manage-configuration.adoc
@@ -10,6 +10,6 @@ To do so your git repository should contains a directory called .bcd_configurati
 
 Into that directory you are able to store encrypted parameters files using this naming convention: parameters-<BCD_CONFIGURATION_NAME>.yml
 
-CAUTION: Ensure to encrypt your parameters file before pushing them on your repository. See the https://docs.ansible.com/ansible/latest/user_guide/vault.html[Ansible Vault documentation] to do so. We also recommend to use private repositories.
+CAUTION: Ensure to encrypt your parameters file before pushing them on your repository. See xref:continuous-delivery:encrypting-configuration.adoc[Encrypting configuration parameters] to do so. We also recommend to use private repositories.
 
 A mandatory step to run your jobs is to configure your vault password as described into xref:continuous-delivery:configuring-the-platform.adoc#repository_credentials[Repository Credentials]


### PR DESCRIPTION
Vault is no longer supported by BCD 4.0.
Previously, a link to the BCD 3.6 was used in the page, but this BCD version is going to be removed from the documentation.
So, the encryption how-to has been integrated into bonita-cloud-doc itself.