### PR TITLE
refactor: use direct xref to UIB

### DIFF
--- a/modules/continuous-delivery/pages/living-application/build-and-deploy.adoc
+++ b/modules/continuous-delivery/pages/living-application/build-and-deploy.adoc
@@ -10,7 +10,7 @@ image:build-deploy-job.png[]
 
 == Launching a deployment
 
-. If your project contains applications created with xref:bonita:ROOT:applications/ui-builder/bonita-ui-builder[Bonita UI Builder], ensure that the UIB application files (`.json`) are placed inside the `uib/` directory in your Git repository.
+. If your project contains applications created with xref:ui-builder::index.adoc[Bonita UI Builder], ensure that the UIB application files (`.json`) are placed inside the `uib/` directory in your Git repository.
 . Click on the image:jenkins-play-button.png[CDPlayButton] of the "ACTION - Build and Deploy a LivingApp to a non-production runtime" job.
 . Your default build and deploy configuration will be pre-loaded. If needed you can change it (includes the repository URL and branch)
 . Select the target AppRuntime (note that only non-production AppRuntimes are available - to deploy in production see xref:living-application//deploying-to-bonita-cloud.adoc[here])

--- a/modules/continuous-delivery/pages/living-application/deploy-in-prod-with-bonita-cloud.adoc
+++ b/modules/continuous-delivery/pages/living-application/deploy-in-prod-with-bonita-cloud.adoc
@@ -12,7 +12,7 @@ image:prod-build-form.png[]
 
 == Launching a deployment
 
-. If your project contains applications created with xref:bonita:ROOT:applications/ui-builder/bonita-ui-builder[Bonita UI Builder], ensure that the UIB application files (`.json`) are placed inside the `uib/` directory in your Git repository.
+. If your project contains applications created with xref:ui-builder::index.adoc[Bonita UI Builder], ensure that the UIB application files (`.json`) are placed inside the `uib/` directory in your Git repository.
 . Click on the image:jenkins-play-button.png[CDPlayButton] of the "ACTION - Deploy a LivingApp to a production runtime" job.
 . Your default deploy configuration will be pre-loaded. If needed you can change it.
 . You still need to select the build you want to deploy.

--- a/modules/continuous-delivery/pages/living-application/deploying-to-bonita-cloud.adoc
+++ b/modules/continuous-delivery/pages/living-application/deploying-to-bonita-cloud.adoc
@@ -12,7 +12,7 @@ image:non-prod-build-form.png[]
 
 == Launching a deployment
 
-. If your project contains applications created with xref:bonita:ROOT:applications/ui-builder/bonita-ui-builder[Bonita UI Builder], ensure that the UIB application files (`.json`) are placed inside the `uib/` directory in your Git repository.
+. If your project contains applications created with xref:ui-builder::index.adoc[Bonita UI Builder], ensure that the UIB application files (`.json`) are placed inside the `uib/` directory in your Git repository.
 . Click on the image:jenkins-play-button.png[CDPlayButton] of the "ACTION - Deploy a LivingApp to a non-production runtime" job.
 . Your default deploy configuration will be pre-loaded. If needed you can change it.
 . You still need to select the build you want to deploy.

--- a/modules/continuous-delivery/pages/living-application/deploying-uib-apps.adoc
+++ b/modules/continuous-delivery/pages/living-application/deploying-uib-apps.adoc
@@ -6,7 +6,7 @@ NOTE: This job is only useful for versions of Bonita >= 2024.3/10.2.
 
 == Deploy Job
 
-The job **"ACTION - Deploy UIB application files"** allows you to deploy your xref:bonita:ROOT:applications/ui-builder/bonita-ui-builder[Bonita UI Builder] applications.
+The job **"ACTION - Deploy UIB application files"** allows you to deploy your xref:ui-builder::index.adoc[Bonita UI Builder] applications.
 
 image:deploy-uib-job.png[]
 
@@ -14,7 +14,7 @@ image:deploy-uib-job-form.png[scaledwidth=60%]
 
 [NOTE]
 ====
-This job is **automatically launched** as part of the LivingApp deployment process.  
+This job is **automatically launched** as part of the LivingApp deployment process.
 You **do not need to trigger this job manually** unless you want to **deploy UIB applications only** without redeploying the LivingApps.
 ====
 


### PR DESCRIPTION
The former syntax targeted the old location in the bonita component and generated warning because it targeted a folder
and not a page.